### PR TITLE
Make logger synchronous by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Logrus Graylog hook
+
+## 1.1.0 - 2015-12-04
+
+* The default behavior is now to send the logs synchronously.
+* A new asynchronous hook is available through `NewAsyncGraylogHook`
+
+

--- a/README.md
+++ b/README.md
@@ -18,12 +18,30 @@ The hook must be configured with:
 import (
     "log/syslog"
     "github.com/Sirupsen/logrus"
-    "github.com/gemnasium/logrus-hooks/graylog"
+    "gopkg.in/gemnasium/logrus-graylog-hook.v1"
     )
 
 func main() {
     log := logrus.New()
     hook := graylog.NewGraylogHook("<graylog_ip>:<graylog_port>", "some_facility", map[string]interface{}{"this": "is logged every time"})
+    log.Hooks.Add(hook)
+    log.Info("some logging message")
+}
+```
+
+### Asynchronous logger
+
+```go
+import (
+    "log/syslog"
+    "github.com/Sirupsen/logrus"
+    "gopkg.in/gemnasium/logrus-graylog-hook.v1"
+    )
+
+func main() {
+    log := logrus.New()
+    hook := graylog.NewAsyncGraylogHook("<graylog_ip>:<graylog_port>", "some_facility", map[string]interface{}{"this": "is logged every time"})
+    defer hook.Flush()
     log.Hooks.Add(hook)
     log.Info("some logging message")
 }


### PR DESCRIPTION
closes #1

Since the messages are sent in a goroutine, the program won't wait for
the last messages to be sent, resulting in lost logs.
This change introduce a new NewAsyncGraylogHook func to preserve API
compatibility. Users who want to get back the async behavior must now
use the Flush() func.