### PR TITLE
add automatic JSON marshalling of error messages for graylog

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,18 @@
+package graylog
+
+import "encoding/json"
+
+// newMarshalableError builds an error which encodes its error message into JSON
+func newMarshalableError(err error) *marshalableError {
+	return &marshalableError{err}
+}
+
+// a marshalableError is an error that can be encoded into JSON
+type marshalableError struct {
+	err error
+}
+
+// MarshalJSON implements json.Marshaler for marshalableError
+func (m *marshalableError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.err.Error())
+}


### PR DESCRIPTION
This feature makes it so that if an error is reported with `WithError` and it doesn't know how to encode itself as JSON, the error's string is used to encode the error.

This makes it so that the error messages sent to Graylog via `WithError` are more useful than an empty object `{}` as they are currently sent.