### PR TITLE
Concurrency fixes

### DIFF
--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -54,7 +54,8 @@ func NewGraylogHook(addr string, facility string, extra map[string]interface{}) 
 }
 
 // NewAsyncGraylogHook creates a hook to be added to an instance of logger.
-// The hook created will be asynchronous, and it's the responsability of the user to call the Flush method to empty the log queue.
+// The hook created will be asynchronous, and it's the responsibility of the user to call the Flush method
+// before exiting to empty the log queue.
 func NewAsyncGraylogHook(addr string, facility string, extra map[string]interface{}) *GraylogHook {
 	g, err := gelf.NewWriter(addr)
 	if err != nil {
@@ -81,7 +82,13 @@ func (hook *GraylogHook) Fire(entry *logrus.Entry) error {
 	gEntry := graylogEntry{entry, file, line}
 	hook.wg.Add(1)
 	hook.buf <- gEntry
-	hook.Flush()
+
+	if hook.synchronous {
+		hook.Flush()
+	} else {
+		go hook.Flush()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes a few issues that we ran into while running this in a few of our apps...


1) ad4e32b - as written the Async logger actually behaved the same as the Sync logger and would always wait for the entry to be sent before returning

2) 6638df5 - a much more interesting problem. If two go routines called Log at the same time, one of them could increment the `wg.Add` counter while the other one had called `Flush` (`wg.Wait`). The Go `sync.WaitGroup` has a check for when this happens (See [waitgroup.go#L129](https://golang.org/src/sync/waitgroup.go)) and panics. 

I added a test that covers this (although most CI only give a single core so the test might never fail on cI anyway) and changed the implementation such that the hook will send the entry directly when sync and otherwise it will use the buffer. Additionally, a `sync.Mutex` is added to prevent additional logging when the `AsyncHook` is being flushed

3) c0f23b0 just switched to a RWMutex allowing multiple go routines to Write simultaneously, while `Flush` still blocks all of them from writing. This is a bit awkward in the naming (since we allow multiple writes and one Read, as opposed to multiple Reads and one Write...).
