### PR TITLE
Remove facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ All logrus fields will be sent as additional fields on Graylog.
 The hook must be configured with:
 
 * A Graylog GELF UDP address (a "ip:port" string).
-* A facility
 * an optional hash with extra global fields. These fields will be included in all messages sent to Graylog
 
 ```go
@@ -23,7 +22,7 @@ import (
 
 func main() {
     log := logrus.New()
-    hook := graylog.NewGraylogHook("<graylog_ip>:<graylog_port>", "some_facility", map[string]interface{}{"this": "is logged every time"})
+    hook := graylog.NewGraylogHook("<graylog_ip>:<graylog_port>", map[string]interface{}{"this": "is logged every time"})
     log.Hooks.Add(hook)
     log.Info("some logging message")
 }
@@ -40,7 +39,7 @@ import (
 
 func main() {
     log := logrus.New()
-    hook := graylog.NewAsyncGraylogHook("<graylog_ip>:<graylog_port>", "some_facility", map[string]interface{}{"this": "is logged every time"})
+    hook := graylog.NewAsyncGraylogHook("<graylog_ip>:<graylog_port>", map[string]interface{}{"this": "is logged every time"})
     defer hook.Flush()
     log.Hooks.Add(hook)
     log.Info("some logging message")

--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -1,4 +1,4 @@
-package graylog // import "gopkg.in/gemnasium/logrus-graylog-hook.v1"
+package graylog
 
 import (
 	"bytes"
@@ -21,7 +21,6 @@ var BufSize uint = 8192
 
 // GraylogHook to send logs to a logging service compatible with the Graylog API and the GELF format.
 type GraylogHook struct {
-	Facility    string
 	Extra       map[string]interface{}
 	gelfLogger  *gelf.Writer
 	buf         chan graylogEntry
@@ -38,13 +37,12 @@ type graylogEntry struct {
 }
 
 // NewGraylogHook creates a hook to be added to an instance of logger.
-func NewGraylogHook(addr string, facility string, extra map[string]interface{}) *GraylogHook {
+func NewGraylogHook(addr string, extra map[string]interface{}) *GraylogHook {
 	g, err := gelf.NewWriter(addr)
 	if err != nil {
 		logrus.WithField("err", err).Info("Can't create Gelf logger")
 	}
 	hook := &GraylogHook{
-		Facility:    facility,
 		Extra:       extra,
 		gelfLogger:  g,
 		synchronous: true,
@@ -55,13 +53,12 @@ func NewGraylogHook(addr string, facility string, extra map[string]interface{}) 
 // NewAsyncGraylogHook creates a hook to be added to an instance of logger.
 // The hook created will be asynchronous, and it's the responsibility of the user to call the Flush method
 // before exiting to empty the log queue.
-func NewAsyncGraylogHook(addr string, facility string, extra map[string]interface{}) *GraylogHook {
+func NewAsyncGraylogHook(addr string, extra map[string]interface{}) *GraylogHook {
 	g, err := gelf.NewWriter(addr)
 	if err != nil {
 		logrus.WithField("err", err).Info("Can't create Gelf logger")
 	}
 	hook := &GraylogHook{
-		Facility:   facility,
 		Extra:      extra,
 		gelfLogger: g,
 		buf:        make(chan graylogEntry, BufSize),
@@ -171,7 +168,6 @@ func (hook *GraylogHook) sendEntry(entry graylogEntry) {
 		Full:     string(full),
 		TimeUnix: time.Now().Unix(),
 		Level:    level,
-		Facility: hook.Facility,
 		File:     entry.file,
 		Line:     entry.line,
 		Extra:    extra,

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -20,7 +20,7 @@ func TestWritingToUDP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewReader: %s", err)
 	}
-	hook := NewGraylogHook(r.Addr(), "test_facility", map[string]interface{}{"foo": "bar"})
+	hook := NewGraylogHook(r.Addr(), map[string]interface{}{"foo": "bar"})
 	msgData := "test message\nsecond line"
 
 	log := logrus.New()
@@ -43,10 +43,6 @@ func TestWritingToUDP(t *testing.T) {
 
 	if msg.Level != SyslogInfoLevel {
 		t.Errorf("msg.Level: expected: %d, got %d)", SyslogInfoLevel, msg.Level)
-	}
-
-	if msg.Facility != "test_facility" {
-		t.Errorf("msg.Facility: expected %#v, got %#v)", "test_facility", msg.Facility)
 	}
 
 	if len(msg.Extra) != 2 {
@@ -82,7 +78,7 @@ func testErrorLevelReporting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewReader: %s", err)
 	}
-	hook := NewGraylogHook(r.Addr(), "test_facility", map[string]interface{}{"foo": "bar"})
+	hook := NewGraylogHook(r.Addr(), map[string]interface{}{"foo": "bar"})
 	msgData := "test message\nsecond line"
 
 	log := logrus.New()
@@ -114,7 +110,7 @@ func TestJSONErrorMarshalling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewReader: %s", err)
 	}
-	hook := NewGraylogHook(r.Addr(), "test_facility", map[string]interface{}{})
+	hook := NewGraylogHook(r.Addr(), map[string]interface{}{})
 
 	log := logrus.New()
 	log.Hooks.Add(hook)
@@ -142,8 +138,8 @@ func TestParallelLogging(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewReader: %s", err)
 	}
-	hook := NewGraylogHook(r.Addr(), "test_facility", nil)
-	asyncHook := NewAsyncGraylogHook(r.Addr(), "test_facility", nil)
+	hook := NewGraylogHook(r.Addr(), nil)
+	asyncHook := NewAsyncGraylogHook(r.Addr(), nil)
 
 	log := logrus.New()
 	log.Hooks.Add(hook)


### PR DESCRIPTION
According to the documentation, 'facility' is deprecated and should be included as an additional field instead if wanted:

http://docs.graylog.org/en/2.0/pages/gelf.html