### PR TITLE
Add support for extracting stacktraces from errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package graylog
 
 import (
 	"encoding/json"
+	"runtime"
 
 	"github.com/pkg/errors"
 )
@@ -45,4 +46,10 @@ func extractStackTrace(err error) errors.StackTrace {
 		return nil
 	}
 	return tracer.StackTrace()
+}
+
+func extractFileAndLine(stacktrace errors.StackTrace) (string, int) {
+	pc := uintptr(stacktrace[0])
+	fn := runtime.FuncForPC(pc)
+	return fn.FileLine(pc)
 }

--- a/error.go
+++ b/error.go
@@ -1,6 +1,10 @@
 package graylog
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
 
 // newMarshalableError builds an error which encodes its error message into JSON
 func newMarshalableError(err error) *marshalableError {
@@ -15,4 +19,30 @@ type marshalableError struct {
 // MarshalJSON implements json.Marshaler for marshalableError
 func (m *marshalableError) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.err.Error())
+}
+
+type causer interface {
+	Cause() error
+}
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+func extractStackTrace(err error) errors.StackTrace {
+	var tracer stackTracer
+	for {
+		if st, ok := err.(stackTracer); ok {
+			tracer = st
+		}
+		if cause, ok := err.(causer); ok {
+			err = cause.Cause()
+			continue
+		}
+		break
+	}
+	if tracer == nil {
+		return nil
+	}
+	return tracer.StackTrace()
 }

--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -178,6 +178,11 @@ func (hook *GraylogHook) sendEntry(entry graylogEntry) {
 				}
 				if stackTrace := extractStackTrace(asError); stackTrace != nil {
 					extra[StackTraceKey] = fmt.Sprintf("%+v", stackTrace)
+					file, line := extractFileAndLine(stackTrace)
+					if file != "" && line != 0 {
+						entry.file = file
+						entry.line = line
+					}
 				}
 			} else {
 				extra[extraK] = v

--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+const StackTraceKey = "_stacktrace"
+
 // Set graylog.BufSize = <value> _before_ calling NewGraylogHook
 // Once the buffer is full, logging will start blocking, waiting for slots to
 // be available in the queue.
@@ -174,6 +176,9 @@ func (hook *GraylogHook) sendEntry(entry graylogEntry) {
 				} else {
 					extra[extraK] = v
 				}
+				if stackTrace := extractStackTrace(asError); stackTrace != nil {
+					extra[StackTraceKey] = fmt.Sprintf("%+v", stackTrace)
+				}
 			} else {
 				extra[extraK] = v
 			}
@@ -195,7 +200,6 @@ func (hook *GraylogHook) sendEntry(entry graylogEntry) {
 	if err := w.WriteMessage(&m); err != nil {
 		fmt.Println(err)
 	}
-
 }
 
 // Levels returns the available logging levels.

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	pkgerrors "github.com/pkg/errors"
 )
 
 const SyslogInfoLevel = 6
@@ -63,8 +64,9 @@ func TestWritingToUDP(t *testing.T) {
 			msg.File)
 	}
 
-	if msg.Line != 32 { // Update this if code is updated above
-		t.Errorf("msg.Line: expected %d, got %d", 32, msg.Line)
+	lineExpected := 33 // Update this if code is updated above
+	if msg.Line != lineExpected {
+		t.Errorf("msg.Line: expected %d, got %d", lineExpected, msg.Line)
 	}
 
 	if len(msg.Extra) != 2 {
@@ -221,5 +223,43 @@ func TestSetWriter(t *testing.T) {
 
 	if hook.SetWriter(nil) == nil {
 		t.Error("Setting a nil writter should raise an error")
+	}
+}
+
+func TestStackTracer(t *testing.T) {
+	r, err := NewReader("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewReader: %s", err)
+	}
+	hook := NewGraylogHook(r.Addr(), map[string]interface{}{})
+
+	log := logrus.New()
+	log.Out = ioutil.Discard
+	log.Hooks.Add(hook)
+
+	log.WithError(pkgerrors.New("sample error")).Info("Testing sample error")
+
+	msg, err := r.ReadMessage()
+	if err != nil {
+		t.Errorf("ReadMessage: %s", err)
+	}
+
+	stacktraceI, ok := msg.Extra[StackTraceKey]
+	if !ok {
+		t.Error("Stack Trace not found in result")
+	}
+	stacktrace, ok := stacktraceI.(string)
+	if !ok {
+		t.Error("Stack Trace is not a string")
+	}
+	stacktraceRE := regexp.MustCompile(`^
+gopkg.in/gemnasium/logrus-graylog-hook%2ev2.TestStackTracer
+	/.*gopkg.in/gemnasium/logrus-graylog-hook.v2/graylog_hook_test.go:\d+
+testing.tRunner
+	/.*/testing.go:\d+
+runtime.*
+	/.*/runtime/.*:\d+$`)
+	if !stacktraceRE.MatchString(stacktrace) {
+		t.Errorf("Stack Trace not as expected. Got:\n%s\n", stacktrace)
 	}
 }

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -237,11 +237,24 @@ func TestStackTracer(t *testing.T) {
 	log.Out = ioutil.Discard
 	log.Hooks.Add(hook)
 
-	log.WithError(pkgerrors.New("sample error")).Info("Testing sample error")
+	stackErr := pkgerrors.New("sample error")
+
+	log.WithError(stackErr).Info("Testing sample error")
 
 	msg, err := r.ReadMessage()
 	if err != nil {
 		t.Errorf("ReadMessage: %s", err)
+	}
+
+	fileExpected := "graylog_hook_test.go"
+	if !strings.HasSuffix(msg.File, fileExpected) {
+		t.Errorf("msg.File: expected %s, got %s", fileExpected,
+			msg.File)
+	}
+
+	lineExpected := 240 // Update this if code is updated above
+	if msg.Line != lineExpected {
+		t.Errorf("msg.Line: expected %d, got %d", lineExpected, msg.Line)
 	}
 
 	stacktraceI, ok := msg.Extra[StackTraceKey]


### PR DESCRIPTION
The [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors) package includes stack traces in error values. This adds support for extracting them, and including them as a '_stacktrace' field in a GELF message.