### PR TITLE
Add support to specify logging levels

### DIFF
--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -25,6 +25,7 @@ var BufSize uint = 8192
 type GraylogHook struct {
 	Extra       map[string]interface{}
 	Host        string
+	Level       logrus.Level
 	gelfLogger  *Writer
 	buf         chan graylogEntry
 	wg          sync.WaitGroup
@@ -55,6 +56,7 @@ func NewGraylogHook(addr string, extra map[string]interface{}) *GraylogHook {
 	hook := &GraylogHook{
 		Host:        host,
 		Extra:       extra,
+		Level:       logrus.DebugLevel,
 		gelfLogger:  g,
 		synchronous: true,
 	}
@@ -78,6 +80,7 @@ func NewAsyncGraylogHook(addr string, extra map[string]interface{}) *GraylogHook
 	hook := &GraylogHook{
 		Host:       host,
 		Extra:      extra,
+		Level:      logrus.DebugLevel,
 		gelfLogger: g,
 		buf:        make(chan graylogEntry, BufSize),
 	}
@@ -209,14 +212,13 @@ func (hook *GraylogHook) sendEntry(entry graylogEntry) {
 
 // Levels returns the available logging levels.
 func (hook *GraylogHook) Levels() []logrus.Level {
-	return []logrus.Level{
-		logrus.PanicLevel,
-		logrus.FatalLevel,
-		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
+	levels := []logrus.Level{}
+	for _, level := range logrus.AllLevels {
+		if level <= hook.Level {
+			levels = append(levels, level)
+		}
 	}
+	return levels
 }
 
 // Blacklist create a blacklist map to filter some message keys.

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -266,8 +266,8 @@ func TestStackTracer(t *testing.T) {
 		t.Error("Stack Trace is not a string")
 	}
 	stacktraceRE := regexp.MustCompile(`^
-gopkg.in/gemnasium/logrus-graylog-hook%2ev2.TestStackTracer
-	/.*gopkg.in/gemnasium/logrus-graylog-hook.v2/graylog_hook_test.go:\d+
+.+/logrus-graylog-hook(%2ev2)?.TestStackTracer
+	/.+/logrus-graylog-hook(.v2)?/graylog_hook_test.go:\d+
 testing.tRunner
 	/.*/testing.go:\d+
 runtime.*


### PR DESCRIPTION
This PR adds ability to specify logging level for a hook. It's useful when there are several different logging locations, like file for detailed logs and graylog for errors.