### PR TITLE
Use logrus ReportCaller to get file, line and function

### DIFF
--- a/gelf_writer.go
+++ b/gelf_writer.go
@@ -266,9 +266,6 @@ func (w *Writer) Warning(m string) (err error)
 // the server specified in New().
 func (w *Writer) Write(p []byte) (n int, err error) {
 
-	// 1 for the function that called us.
-	file, line := getCallerIgnoringLogMulti(1)
-
 	// remove trailing and leading whitespace
 	p = bytes.TrimSpace(p)
 
@@ -291,8 +288,6 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		TimeUnix: float64(time.Now().UnixNano()/1000000) / 1000.,
 		Level:    6, // info
 		Facility: w.Facility,
-		File:     file,
-		Line:     line,
 		Extra:    map[string]interface{}{},
 	}
 


### PR DESCRIPTION
This pull request is realted to issue #38 

Logrus now can provide the caller file, line and function is the reportCaller field is set to true.

This PR is to use Logrus existing functionality instead of the hook's similar implementation.

Gelf format consider File and Line fields deprecated and suggest to use additional fields instead. 
In order to minimize side effects File and Line are still populated with the correct values if  reportCaller field is set to true.

In short the changes are the following:

A. When reportCaller is set to true then three additional fields **_file**, **_method** and **_line** are added. **File** and **Line** field use the same values as **_file** and **_line** 

B. When reportCaller is set to false then three additional fields **_file**, **_method** and **_line** are NOT added. **File** and **Line** field use the **zero values** of their corresponding types, . "" and 0 respectively.

Tests to cover the above two senarios are included
