### PR TITLE
Append v3 in module path and update travis configuration to use go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ go:
   - "1.10"
   - "1.11"
   - "tip"
-install:
-  - mkdir -p $HOME/gopath/src/gopkg.in/gemnasium
-  - mv $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook $HOME/gopath/src/gopkg.in/gemnasium/logrus-graylog-hook.v2
-  - cd $HOME/gopath/src/gopkg.in/gemnasium/logrus-graylog-hook.v2
-  - go get -t
+
+env:
+  - GO111MODULE=on
+
+install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,9 @@ go:
 
 env:
   - GO111MODULE=on
+
+install: true
+
+script:
+  - env GO111MODULE=on go build
+  - env GO111MODULE=on go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,3 @@ go:
 
 env:
   - GO111MODULE=on
-
-install:
-  - mkdir -p $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook/v3
-  - mv $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook/v3
-  - cd $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook/v3
-
-script:
-  - env GO111MODULE=on go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ go:
   - "1.11"
   - "tip"
 
-env:
-  - GO111MODULE=on
-
 install: true
 
 script:
-  - env GO111MODULE=on go build
   - env GO111MODULE=on go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,3 @@ go:
 
 env:
   - GO111MODULE=on
-
-install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,13 @@ go:
   - "1.11"
   - "tip"
 
-install: true
+env:
+  - GO111MODULE=on
+
+install:
+  - mkdir -p $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook/v3
+  - mv $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook/v3
+  - cd $HOME/gopath/src/github.com/gemnasium/logrus-graylog-hook/v3
 
 script:
   - env GO111MODULE=on go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gemnasium/logrus-graylog-hook
+module github.com/gemnasium/logrus-graylog-hook/v3
 
 require (
 	github.com/pkg/errors v0.8.1

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -284,7 +284,10 @@ func TestStackTracer(t *testing.T) {
 	if !ok {
 		t.Error("Stack Trace is not a string")
 	}
-	stacktraceRE := regexp.MustCompile(`^
+
+	// Run the test for stack trace only in stable versions
+	if !strings.Contains(runtime.Version(), "devel") {
+		stacktraceRE := regexp.MustCompile(`^
 (.+)?logrus-graylog-hook(%2ev2)?.TestStackTracer
 	(/|[A-Z]:/).+/logrus-graylog-hook(.v2)?/graylog_hook_test.go:\d+
 testing.tRunner
@@ -292,21 +295,9 @@ testing.tRunner
 runtime.*
 	(/|[A-Z]:/).*/runtime/.*:\d+$`)
 
-	// Change the regex when running test on devel version since stack trace on devel is unpredictable
-	if strings.Contains(runtime.Version(), "devel") {
-		stacktraceRE = regexp.MustCompile(`^
-(.+)?logrus-graylog-hook(%2ev2)?.TestStackTracer
-	(/|[A-Z]:/).*/errors.go:\d+
-runtime.skipPleaseUseCallersFrames
-	(/|[A-Z]:/).*/asm.s:\d+
-testing.tRunner
-	(/|[A-Z]:/).*/testing.go:\d+
-runtime.*
-	(/|[A-Z]:/).*/runtime/.*:\d+$`)
-	}
-
-	if !stacktraceRE.MatchString(stacktrace) {
-		t.Errorf("Stack Trace not as expected. Got:\n%s\n", stacktrace)
+		if !stacktraceRE.MatchString(stacktrace) {
+			t.Errorf("Stack Trace not as expected. Got:\n%s\n", stacktrace)
+		}
 	}
 }
 

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -385,7 +385,7 @@ func TestReportCallerEnabled(t *testing.T) {
 		t.Error("_line dowes not have the correct type")
 	}
 
-	lineExpected := 364 // Update this if code is updated above
+	lineExpected := 355 // Update this if code is updated above
 	if msg.Line != lineExpected {
 		t.Errorf("msg.Extra[\"_line\"]: expected %d, got %d", lineExpected, int(lineGot))
 	}
@@ -411,7 +411,7 @@ func TestReportCallerEnabled(t *testing.T) {
 			msg.File)
 	}
 
-	gelfLineExpected := 349 // Update this if code is updated above
+	gelfLineExpected := 355 // Update this if code is updated above
 	if msg.Line != lineExpected {
 		t.Errorf("msg.Line: expected %d, got %d", gelfLineExpected, msg.Line)
 	}

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -288,8 +288,8 @@ func TestStackTracer(t *testing.T) {
 	// Run the test for stack trace only in stable versions
 	if !strings.Contains(runtime.Version(), "devel") {
 		stacktraceRE := regexp.MustCompile(`^
-(.+)?logrus-graylog-hook(%2ev2)?.TestStackTracer
-	(/|[A-Z]:/).+/logrus-graylog-hook(.v2)?/graylog_hook_test.go:\d+
+(.+)?logrus-graylog-hook(%2ev3)?.TestStackTracer
+	(/|[A-Z]:/).+/logrus-graylog-hook(.v3)?/graylog_hook_test.go:\d+
 testing.tRunner
 	(/|[A-Z]:/).*/testing.go:\d+
 runtime.*

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -288,7 +288,7 @@ func TestStackTracer(t *testing.T) {
 	// Run the test for stack trace only in stable versions
 	if !strings.Contains(runtime.Version(), "devel") {
 		stacktraceRE := regexp.MustCompile(`^
-(.+)?logrus-graylog-hook(%2ev3)?.TestStackTracer
+(.+)?logrus-graylog-hook(/v3)?.TestStackTracer
 	(/|[A-Z]:/).+/logrus-graylog-hook(.v3)?/graylog_hook_test.go:\d+
 testing.tRunner
 	(/|[A-Z]:/).*/testing.go:\d+


### PR DESCRIPTION
According to official docs the module path should be 

github.com/gemnasium/logrus-graylog-hook/v3

and not 

github.com/gemnasium/logrus-graylog-hook

This is the official documentation for reference:

https://github.com/golang/go/wiki/Modules#semantic-import-versioning

- If the module is version v2 or higher, **the major version of the module must be included as a /vN at the end of the module paths used in go.mod files** (e.g., module github.com/my/mod/v2, require github.com/my/mod/v2 v2.0.0) and in the package import path (e.g., import "github.com/my/mod/v2/mypkg").
- If the module is version v0 or v1, do not include the major version in either the module path or the import path.

Also

https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher

Major branch: Update the go.mod file **to include a /v3 at the end of the module path** in the module directive (e.g., module github.com/my/module/v3). 
