### PR TITLE
Add http connector

### DIFF
--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -88,7 +88,7 @@ func NewAsyncGraylogHook(addr string, extra map[string]interface{}) *GraylogHook
 
 // Fire is called when a log event is fired.
 // We assume the entry will be altered by another hook,
-// otherwise we might logging something wrong to Graylog
+// otherwise we might be logging something wrong to Graylog
 func (hook *GraylogHook) Fire(entry *logrus.Entry) error {
 	hook.mu.RLock() // Claim the mutex as a RLock - allowing multiple go routines to log simultaneously
 	defer hook.mu.RUnlock()
@@ -144,7 +144,7 @@ func (hook *GraylogHook) fire() {
 	}
 }
 
-func logrusLevelToSylog(level logrus.Level) int32 {
+func logrusLevelToSyslog(level logrus.Level) int32 {
 	const (
 		LOG_EMERG   = 0 /* system is unusable */
 		LOG_ALERT   = 1 /* action must be taken immediately */
@@ -196,7 +196,7 @@ func (hook *GraylogHook) sendEntry(entry graylogEntry) {
 		full = p
 	}
 
-	level := logrusLevelToSylog(entry.Level)
+	level := logrusLevelToSyslog(entry.Level)
 
 	// Don't modify entry.Data directly, as the entry will used after this hook was fired
 	extra := map[string]interface{}{}

--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -24,7 +24,7 @@ type GraylogHook struct {
 	Extra       map[string]interface{}
 	Host        string
 	Level       logrus.Level
-	gelfLogger  *Writer
+	gelfLogger  GELFWriter
 	buf         chan graylogEntry
 	wg          sync.WaitGroup
 	mu          sync.RWMutex
@@ -58,6 +58,7 @@ func NewGraylogHook(addr string, extra map[string]interface{}) *GraylogHook {
 		gelfLogger:  g,
 		synchronous: true,
 	}
+
 	return hook
 }
 
@@ -83,6 +84,7 @@ func NewAsyncGraylogHook(addr string, extra map[string]interface{}) *GraylogHook
 		buf:        make(chan graylogEntry, BufSize),
 	}
 	go hook.fire() // Log in background
+
 	return hook
 }
 
@@ -270,8 +272,8 @@ func (hook *GraylogHook) Blacklist(b []string) {
 	}
 }
 
-// SetWriter sets the hook Gelf Writer
-func (hook *GraylogHook) SetWriter(w *Writer) error {
+// SetWriter sets the hook Gelf writer
+func (hook *GraylogHook) SetWriter(w *UDPWriter) error {
 	if w == nil {
 		return errors.New("writer can't be nil")
 	}
@@ -279,7 +281,7 @@ func (hook *GraylogHook) SetWriter(w *Writer) error {
 	return nil
 }
 
-// Writer returns the logger Gelf Writer
-func (hook *GraylogHook) Writer() *Writer {
+// Writer returns the writer
+func (hook *GraylogHook) Writer() GELFWriter {
 	return hook.gelfLogger
 }

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const SyslogInfoLevel = 6
-const SyslogErrorLevel = 7
+const SyslogErrorLevel = 3
 
 func TestWritingToUDP(t *testing.T) {
 	r, err := NewReader("127.0.0.1:0")
@@ -78,14 +78,14 @@ func TestWritingToUDP(t *testing.T) {
 	extra := map[string]interface{}{"foo": "bar", "withField": "1"}
 
 	for k, v := range extra {
-		// Remember extra fileds are prefixed with "_"
+		// Remember extra fields are prefixed with "_"
 		if msg.Extra["_"+k].(string) != extra[k].(string) {
 			t.Errorf("Expected extra '%s' to be %#v, got %#v", k, v, msg.Extra["_"+k])
 		}
 	}
 }
 
-func testErrorLevelReporting(t *testing.T) {
+func TestErrorLevelReporting(t *testing.T) {
 	r, err := NewReader("127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("NewReader: %s", err)
@@ -311,32 +311,32 @@ func TestLogrusLevelToSylog(t *testing.T) {
 		LOG_DEBUG   = 7 /* debug-level messages */
 	)
 
-	if logrusLevelToSylog(logrus.TraceLevel) != LOG_DEBUG {
-		t.Error("logrusLevelToSylog(TraceLevel) != LOG_DEBUG")
+	if logrusLevelToSyslog(logrus.TraceLevel) != LOG_DEBUG {
+		t.Error("logrusLevelToSyslog(TraceLevel) != LOG_DEBUG")
 	}
 
-	if logrusLevelToSylog(logrus.DebugLevel) != LOG_DEBUG {
-		t.Error("logrusLevelToSylog(DebugLevel) != LOG_DEBUG")
+	if logrusLevelToSyslog(logrus.DebugLevel) != LOG_DEBUG {
+		t.Error("logrusLevelToSyslog(DebugLevel) != LOG_DEBUG")
 	}
 
-	if logrusLevelToSylog(logrus.InfoLevel) != LOG_INFO {
-		t.Error("logrusLevelToSylog(InfoLevel) != LOG_INFO")
+	if logrusLevelToSyslog(logrus.InfoLevel) != LOG_INFO {
+		t.Error("logrusLevelToSyslog(InfoLevel) != LOG_INFO")
 	}
 
-	if logrusLevelToSylog(logrus.WarnLevel) != LOG_WARNING {
-		t.Error("logrusLevelToSylog(WarnLevel) != LOG_WARNING")
+	if logrusLevelToSyslog(logrus.WarnLevel) != LOG_WARNING {
+		t.Error("logrusLevelToSyslog(WarnLevel) != LOG_WARNING")
 	}
 
-	if logrusLevelToSylog(logrus.ErrorLevel) != LOG_ERR {
-		t.Error("logrusLevelToSylog(ErrorLevel) != LOG_ERR")
+	if logrusLevelToSyslog(logrus.ErrorLevel) != LOG_ERR {
+		t.Error("logrusLevelToSyslog(ErrorLevel) != LOG_ERR")
 	}
 
-	if logrusLevelToSylog(logrus.FatalLevel) != LOG_CRIT {
-		t.Error("logrusLevelToSylog(FatalLevel) != LOG_CRIT")
+	if logrusLevelToSyslog(logrus.FatalLevel) != LOG_CRIT {
+		t.Error("logrusLevelToSyslog(FatalLevel) != LOG_CRIT")
 	}
 
-	if logrusLevelToSylog(logrus.PanicLevel) != LOG_ALERT {
-		t.Error("logrusLevelToSylog(PanicLevel) != LOG_ALERT")
+	if logrusLevelToSyslog(logrus.PanicLevel) != LOG_ALERT {
+		t.Error("logrusLevelToSyslog(PanicLevel) != LOG_ALERT")
 	}
 }
 


### PR DESCRIPTION
This adds a very basic http writer which can be activated by passing in an url as logging address.

The graylog HTTP input should only be used for low traffic scenarios, but with it it's easier to go "through" a load balancer, especially if these do not support UDP or TCP.

Changes:

* Fix some tests (first commit)
* Fix some typos 
* Renamed Writer to UDPWriter and added a new interface GELFWriter
* Added a HTTPWriter which only implements the GELFWriter interface 