### PR TITLE
Update README.md with some details on flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ import (
 
 func main() {
     hook := graylog.NewAsyncGraylogHook("<graylog_ip>:<graylog_port>", map[string]interface{}{"this": "is logged every time"})
+    // NOTE: you must call Flush() before your program exits to ensure ALL of your logs are sent.
+    // This defer statement will not have that effect if you write it in a non-main() method.
     defer hook.Flush()
     log.AddHook(hook)
     log.Info("some logging message")


### PR DESCRIPTION
While using this library, I noticed 2 spots in my employer's code where this `defer hook.Flush()` code was copied verbatim into a non-`main()` method, completely negating the effect, since the Flush method would only be called at the end of method being used to set up the hook, NOT before the end of program's execution.

This PR attempts to clarify without being overly verbose, open to feedback.

Thanks for providing this library!