### PR TITLE
Fix status code test when posting to graylog

### DIFF
--- a/gelf_writer.go
+++ b/gelf_writer.go
@@ -139,8 +139,8 @@ func newUDPWriter(addr string) (GELFWriter, error) {
 // of GELF chunked messages.  The header format is documented at
 // https://github.com/Graylog2/graylog2-docs/wiki/GELF as:
 //
-//     2-byte magic (0x1e 0x0f), 8 byte id, 1 byte sequence id, 1 byte
-//     total, chunk-data
+//	2-byte magic (0x1e 0x0f), 8 byte id, 1 byte sequence id, 1 byte
+//	total, chunk-data
 func (w *UDPWriter) writeChunked(zBytes []byte) (err error) {
 	b := make([]byte, 0, ChunkSize)
 	buf := bytes.NewBuffer(b)
@@ -407,8 +407,8 @@ func (h HTTPWriter) WriteMessage(m *Message) (err error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 204 {
-		return fmt.Errorf("got code %s, expected 204", resp.Status)
+	if resp.StatusCode != 202 {
+		return fmt.Errorf("got code %s, expected 202", resp.Status)
 	}
 
 	return nil

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -270,7 +270,7 @@ func TestStackTracer(t *testing.T) {
 			msg.File)
 	}
 
-	lineExpected := 258 // Update this if code is updated above
+	lineExpected := 260 // Update this if code is updated above
 	if msg.Line != lineExpected {
 		t.Errorf("msg.Line: expected %d, got %d", lineExpected, msg.Line)
 	}
@@ -388,7 +388,7 @@ func TestReportCallerEnabled(t *testing.T) {
 		t.Error("_line dowes not have the correct type")
 	}
 
-	lineExpected := 356 // Update this if code is updated above
+	lineExpected := 358 // Update this if code is updated above
 	if msg.Line != lineExpected {
 		t.Errorf("msg.Extra[\"_line\"]: expected %d, got %d", lineExpected, int(lineGot))
 	}


### PR DESCRIPTION
When sending HTTP posts to graylog, the status code returned is `202` (`accepted`) and not `204` (`no-content`), according to https://go2docs.graylog.org/5-0/getting_in_log_data/ingest_gelf.html (and for versions 4.x and 3.x and below).

closes #58