### PR TITLE
handling error case

### DIFF
--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -105,7 +105,14 @@ func (hook *GraylogHook) Fire(entry *logrus.Entry) error {
 
 	newData := make(map[string]interface{})
 	for k, v := range entry.Data {
-		newData[k] = v
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/Sirupsen/logrus/issues/137
+			newData[k] = v.Error()
+		default:
+			newData[k] = v
+		}
 	}
 
 	newEntry := &logrus.Entry{


### PR DESCRIPTION
Without this change, errors tend to print as {}, or whatever the
exported fields on the concrete implementation of the error are.

This code borrowed from logrus.JSONFormatter:
https://github.com/sirupsen/logrus/commit/8287db793
https://github.com/sebest/logrusly/pull/4